### PR TITLE
Add camera mismatch evaluation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ Launch a single training run of PPRL + Aux (PointPatchRL with reconstruction los
 python scripts/train_sac.py env=push_chair model=pointgpt_rl algo=aux_sac
 ```
 
+To reproduce the camera mismatch experiments (4 environments × 6 mismatches, one seed each) run
+
+```
+bash scripts/run_all.sh
+```
+
+Each run stores its weights in `model.pt`.  After any training finishes you can
+evaluate the saved policy on all six camera offsets with:
+
+```
+python scripts/eval_camera_mismatches.py env=push_chair model=ppt algo=aux_sac model_path=model.pt
+```
+
+The evaluation script performs ten rollouts for every mismatch and prints the
+average success rate.
+
 
 If you just want to test to see if everything works (fewer parallel environments, smaller batch size, fewer training steps), run:
 ```

--- a/conf/algoXenv/sac_maniskill2.yaml
+++ b/conf/algoXenv/sac_maniskill2.yaml
@@ -13,4 +13,4 @@ batch_T: 640
 # rendering is strange for maniskill envs, so we only use one
 # environment for video recording
 eval:
-  n_eval_envs: 1
+  n_eval_envs: 10

--- a/conf/train_sac.yaml
+++ b/conf/train_sac.yaml
@@ -20,14 +20,16 @@ q_mlp_head:
   hidden_sizes: [1024, 1024, 1024]
   hidden_nonlinearity: ELU
 device: null
+camera_mismatch: none
+model_path: model.pt
 lr_scheduler_gamma: null
 runner:
   n_steps: 1e6
   log_interval_steps: 10000
-  eval_interval_steps: 20000
+  eval_interval_steps: 200000
 eval:
-  n_eval_envs: 4
-  max_trajectories: 100
+  n_eval_envs: 10
+  max_trajectories: 10
 
 wandb:
   tags: null

--- a/pprl/models/ppt.py
+++ b/pprl/models/ppt.py
@@ -68,8 +68,30 @@ class PointPatchTransformer(nn.Module):
         R = torch.tensor([[1-2*(y*y+z*z),   2*(x*y - z*w),     2*(x*z + y*w)],
                           [2*(x*y + z*w),   1-2*(x*x+z*z),     2*(y*z - x*w)],
                           [2*(x*z - y*w),   2*(y*z + x*w),     1-2*(x*x+y*y)]], device=device, dtype=dtype)
-        
+
         return points @ R.T
+
+    def line_distance_sums(self, centered_pcd: Tensor, vec: Tensor) -> tuple[Tensor, Tensor]:
+        proj = centered_pcd @ vec
+        pos_sum = proj[proj >= 0].abs().sum()
+        neg_sum = proj[proj < 0].abs().sum()
+        return pos_sum, neg_sum
+
+    def disambiguate(self, centered_pcd: Tensor, eig_vecs: Tensor) -> Tensor:
+        """
+        Function takes in centered_pcd and returns PCA normalized cloud
+        eig_vecs are row vecs
+        """
+        for i in range(2):
+            pos_sum, neg_sum = self.line_distance_sums(centered_pcd, eig_vecs[i])
+            if neg_sum > pos_sum:
+                eig_vecs[i] *= -1
+        v1 = eig_vecs[0]
+        v2 = eig_vecs[1]
+        v3 = torch.cross(v1, v2)
+        v3 /= v3.norm()
+        eig_vecs = torch.stack([v1, v2, v3], dim=0)
+        return centered_pcd @ eig_vecs.T
 
     def forward(self, observation: ArrayTree[Tensor]) -> Tensor:
 
@@ -98,20 +120,14 @@ class PointPatchTransformer(nn.Module):
 
         if PCA:
             pca_basis_list = [
-                points[ptr[i+1] - 3 : ptr[i+1], :3].T
+                points[ptr[i+1] - 3 : ptr[i+1], :3]
                 for i in range(len(ptr) - 1)
             ]
 
-            pca_bases = torch.stack(pca_basis_list, dim = 0)
-            pca_bases *= (torch.randint(0, 2, (len(pca_basis_list), 3), device=pca_bases.device) * 2 - 1).unsqueeze(1)
-
-            """
-            VERY IMPORTANT, PCA COLUMNS ARE THE BASES, AND ORTHOGONALITY HAS BEEN VERIFIED
-            """
-
-            pca_basis_list = list(pca_bases)
-
-            rotated_list = [point_cloud @ pca_basis for point_cloud, pca_basis in zip(correct_points_list, pca_basis_list)]
+            rotated_list = [
+                self.disambiguate(point_cloud, pca_basis)
+                for point_cloud, pca_basis in zip(correct_points_list, pca_basis_list)
+            ]
         else:
             rotated_list = correct_points_list
 

--- a/scripts/eval_camera_mismatches.py
+++ b/scripts/eval_camera_mismatches.py
@@ -1,0 +1,28 @@
+import numpy as np
+import torch
+from pathlib import Path
+import hydra
+from omegaconf import DictConfig, open_dict
+
+from train_sac import build, CAMERA_MISMATCHES
+
+MISMATCHES = [k for k in CAMERA_MISMATCHES if k != "none"]
+
+
+@hydra.main(version_base=None, config_path="../conf", config_name="train_sac")
+def main(config: DictConfig) -> None:
+    state_dict = torch.load(Path(config.model_path), map_location=config.device)
+    results = {}
+    for name in MISMATCHES:
+        with open_dict(config):
+            config.camera_mismatch = name
+        with build(config) as runner:
+            runner.agent.load_state_dict(state_dict)
+            stats = runner.eval_sampler.evaluate(n_trajs=config.eval.max_trajectories)
+            successes = [info.get("success", 0.0) for info in stats]
+            results[name] = float(np.mean(successes))
+    print(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+ENVS=(open_cabinet_door open_cabinet_drawer push_chair turn_faucet)
+MISMATCHES=(roll15 roll30 x50 y50 z50 view50)
+SEED=0
+i=0
+for env in "${ENVS[@]}"; do
+  for mis in "${MISMATCHES[@]}"; do
+    gpu=$((i % 2))
+    CUDA_VISIBLE_DEVICES=$gpu python scripts/train_sac.py \
+      algo=aux_sac model=ppt env="$env" camera_mismatch="$mis" \
+      seed=$SEED device="cuda:$gpu" wandb.group_name="pprl_aux_${env}_${mis}" &
+    ((i++))
+    if (( i % 2 == 0 )); then wait; fi
+  done
+done
+wait

--- a/scripts/train_sac.py
+++ b/scripts/train_sac.py
@@ -29,6 +29,33 @@ from pprl.utils.array_dict import build_obs_array
 
 from omegaconf import OmegaConf
 
+CAMERA_MISMATCHES = {
+    "none": None,
+    "roll15": {"roll": 15},
+    "roll30": {"roll": 30},
+    "x50": {"shift": [0.05, 0.0, 0.0]},
+    "y50": {"shift": [0.0, 0.05, 0.0]},
+    "z50": {"shift": [0.0, 0.0, 0.05]},
+    "view50": {"view": 0.05},
+}
+
+
+def quat_mul(q1: np.ndarray, q2: np.ndarray) -> np.ndarray:
+    x1, y1, z1, w1 = q1
+    x2, y2, z2, w2 = q2
+    return np.array([
+        w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+        w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+        w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+        w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+    ])
+
+
+def rotate_vec(q: np.ndarray, v: np.ndarray) -> np.ndarray:
+    q_conj = np.array([-q[0], -q[1], -q[2], q[3]])
+    v_q = np.array([v[0], v[1], v[2], 0.0])
+    return quat_mul(quat_mul(q, v_q), q_conj)[:3]
+
 """
 create_scene_kwargs:
   hole_config:
@@ -79,16 +106,7 @@ def build(config: DictConfig) -> Iterator[RLRunner]:
     TrajInfoClass.set_discount(discount)
 
 
-    # config.env.camera_reset_noise = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
-    config.env.camera_reset_noise = None 
-    config.env.create_scene_kwargs.camera_config.placement_kwargs.position = [0.0, -175.0, 120.0]
-    config.env.create_scene_kwargs.camera_config.placement_kwargs.lookAt = [10.0, 0.0, 55.0]
-
-    # config['create_scene_kwargs']['camera_config']['placement_kwargs']['position'] = [0.0, -175.0, 120.0]
-    # config['create_scene_kwargs']['camera_config']['placement_kwargs']['lookAt'] = [10.0, 0.0, 55.0]
-
     env_factory = instantiate(config.env, _convert_="partial", _partial_=True)
-
 
     cages, metadata = build_cages(
         EnvClass=env_factory,
@@ -97,14 +115,25 @@ def build(config: DictConfig) -> Iterator[RLRunner]:
         parallel=parallel,
     )
 
+    mismatch = CAMERA_MISMATCHES.get(config.camera_mismatch)
+    if mismatch:
+        camera_cfgs = config.env.env_kwargs.setdefault("camera_cfgs", {})
+        pose = camera_cfgs.setdefault("pose", {"p": [0.0, 0.0, 0.0], "q": [0.0, 0.0, 0.0, 1.0]})
+        p = np.array(pose.get("p", [0.0, 0.0, 0.0]), dtype=float)
+        q = np.array(pose.get("q", [0.0, 0.0, 0.0, 1.0]), dtype=float)
+        if "shift" in mismatch:
+            p += np.array(mismatch["shift"], dtype=float)
+        if "view" in mismatch:
+            forward = rotate_vec(q, np.array([0.0, 0.0, 1.0]))
+            p += forward * float(mismatch["view"])
+        if "roll" in mismatch:
+            angle = np.deg2rad(float(mismatch["roll"]))
+            s, c = np.sin(angle / 2.0), np.cos(angle / 2.0)
+            roll_q = np.array([0.0, 0.0, s, c])
+            q = quat_mul(q, roll_q)
+        pose["p"] = p.tolist()
+        pose["q"] = q.tolist()
 
-    # config.env.camera_reset_noise = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
-    config.env.camera_reset_noise = None
-    config.env.create_scene_kwargs.camera_config.placement_kwargs.position =[0.,0., 200.]
-    config.env.create_scene_kwargs.camera_config.placement_kwargs.lookAt = [10.0, 0.0, 55.0]
-
-    # config['create_scene_kwargs']['camera_config']['placement_kwargs']['position'] = [200,200 , 200]
-    # config['create_scene_kwargs']['camera_config']['placement_kwargs']['lookAt'] = [10.0, 0.0, 55.0]
     env_factory = instantiate(config.env, _convert_="partial", _partial_=True)
 
     """EVAL CAGE"""
@@ -112,8 +141,7 @@ def build(config: DictConfig) -> Iterator[RLRunner]:
     eval_cages, eval_metadata = build_cages(
         EnvClass=env_factory,
         n_envs=config.eval.n_eval_envs,
-        env_kwargs={"add_rendering_to_info": True,
-                    },
+        env_kwargs={"add_rendering_to_info": True},
         TrajInfoClass=TrajInfoClass,
         parallel=parallel,
     )
@@ -389,8 +417,10 @@ def main(config: DictConfig) -> None:
     )
     config.update({"video_path": video_path})
 
+    model_path = Path(config.get("model_path", "model.pt"))
     with build(config) as runner:
         runner.run()
+        torch.save(runner.agent.state_dict(), model_path)
 
     logger.close()
     run.finish()  # type: ignore


### PR DESCRIPTION
## Summary
- save SAC agent weights after training
- add script to evaluate a saved policy on six camera mismatches with 10 rollouts each
- provide helper script and documentation to launch all PPRL+Aux mismatch experiments
- inline camera mismatch definitions so no per-mismatch config files are needed